### PR TITLE
Interpret 0xFF as an active touch

### DIFF
--- a/src/protocol/internals.rs
+++ b/src/protocol/internals.rs
@@ -202,7 +202,7 @@ pub fn parse_touch_data(reader: &mut Cursor<&[u8]>) -> Result<TouchData> {
 
     match active {
       0 => Ok(false),
-      1 => Ok(true),
+      1 | 255 => Ok(true),
       _ => Err(invalid_data_error("Invalid touch active value"))
     }
   }?;


### PR DESCRIPTION
ds4drv-cemuhook's server uses 255 instead of 1 for the touch active byte, and it works with Cemu's client, whereas pad-motion currently silently ignores messages from ds4drv-cemuhook with active touches.

With this change both 1 and 255 are accepted.

I also submitted a pull request to ds4drv-cemuhook to fix it client-side: TheDrHax/ds4drv-cemuhook#13