### PR TITLE
Thread park

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -270,7 +270,7 @@ impl DsServer for Arc<Server> {
                 if let Ok((amount, source)) = self.socket.recv_from(&mut buf) {
                     let message = parse_message(MessageSource::Client, &buf[..amount], true);
                     if let Ok(message) = message {
-                        if !receiving_requests.load(Ordering::Acquire) {receiving_requests.store(true, Ordering::Release)};
+                        receiving_requests.store(true, Ordering::Release);
                         let _ = self.handle_request(source, message);
                     }
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -267,7 +267,6 @@ impl DsServer for Arc<Server> {
         std::thread::spawn(move || {
             let mut buf = [0_u8; 100];
             while countinue_running.load(Ordering::SeqCst) {
-                println!("{}", receiving_requests.load(Ordering::SeqCst));
                 if let Ok((amount, source)) = self.socket.recv_from(&mut buf) {
                     let message = parse_message(MessageSource::Client, &buf[..amount], true);
                     if let Ok(message) = message {

--- a/src/server.rs
+++ b/src/server.rs
@@ -270,7 +270,7 @@ impl DsServer for Arc<Server> {
                 if let Ok((amount, source)) = self.socket.recv_from(&mut buf) {
                     let message = parse_message(MessageSource::Client, &buf[..amount], true);
                     if let Ok(message) = message {
-                        receiving_requests.store(true, Ordering::Release);
+                        if !receiving_requests.load(Ordering::Acquire) {receiving_requests.store(true, Ordering::Release)};
                         let _ = self.handle_request(source, message);
                     }
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -300,6 +300,7 @@ impl DsServer for Arc<Server> {
     }
 
     fn get_connected_clients(&self) -> u8 {
-        4
+        let connected_clients = self.connected_clients.lock().unwrap();
+        connected_clients.len() as u8
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -224,6 +224,7 @@ impl Server {
                     }
                     MessagePayload::ControllerDataRequest(request) => {
                         {
+                            println!("Request here");
                             let mut connected_clients = self.connected_clients.lock().unwrap();
                             let requested = connected_clients.entry(source).or_insert(
                                 RequestedControllerData {

--- a/src/server.rs
+++ b/src/server.rs
@@ -267,6 +267,7 @@ impl DsServer for Arc<Server> {
         std::thread::spawn(move || {
             let mut buf = [0_u8; 100];
             while countinue_running.load(Ordering::SeqCst) {
+                println!("{}", receiving_requests.load(Ordering::SeqCst));
                 if let Ok((amount, source)) = self.socket.recv_from(&mut buf) {
                     let message = parse_message(MessageSource::Client, &buf[..amount], true);
                     if let Ok(message) = message {

--- a/src/server.rs
+++ b/src/server.rs
@@ -270,7 +270,7 @@ impl DsServer for Arc<Server> {
                 if let Ok((amount, source)) = self.socket.recv_from(&mut buf) {
                     let message = parse_message(MessageSource::Client, &buf[..amount], true);
                     if let Ok(message) = message {
-                        if !receiving_requests.load(Ordering::Acquire) {receiving_requests.store(true, Ordering::Release)};
+                        if !receiving_requests.load(Ordering::SeqCst) {receiving_requests.store(true, Ordering::SeqCst)};
                         let _ = self.handle_request(source, message);
                     }
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,8 @@ pub trait DsServer {
 
     /// Update controller data (it will automatically send this data to connected clients).
     fn update_controller_data(&self, slot_number: u8, controller_data: ControllerData);
+
+    fn get_connected_clients(&self) -> u8;
 }
 
 pub struct Server {
@@ -295,5 +297,9 @@ impl DsServer for Arc<Server> {
         }
 
         let _ = self.send_controller_data();
+    }
+
+    fn get_connected_clients(&self) -> u8 {
+        4
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::thread::JoinHandle;
+use std::thread::{JoinHandle, Thread};
 use std::time::{Duration, Instant};
 
 use crate::protocol::*;
@@ -27,7 +27,7 @@ const DEFAULT_PORT: u16 = 26760;
 
 pub trait DsServer {
     /// Starts background server thread.
-    fn start(self, countinue_running: Arc<AtomicBool>, receiving_requests: Arc<AtomicBool>) -> JoinHandle<()>;
+    fn start(self, countinue_running: Arc<AtomicBool>, receiving_requests: Arc<AtomicBool>, parent: Thread) -> JoinHandle<()>;
 
     /// Update controller info (it will automatically send this data to connected clients).
     fn update_controller_info(&self, controller_info: ControllerInfo);
@@ -263,7 +263,7 @@ impl Server {
 }
 
 impl DsServer for Arc<Server> {
-    fn start(self, countinue_running: Arc<AtomicBool>, receiving_requests: Arc<AtomicBool> ) -> JoinHandle<()> {
+    fn start(self, countinue_running: Arc<AtomicBool>, receiving_requests: Arc<AtomicBool>, parent: Thread) -> JoinHandle<()> {
         std::thread::spawn(move || {
             let mut buf = [0_u8; 100];
             while countinue_running.load(Ordering::SeqCst) {
@@ -271,7 +271,10 @@ impl DsServer for Arc<Server> {
                 if let Ok((amount, source)) = self.socket.recv_from(&mut buf) {
                     let message = parse_message(MessageSource::Client, &buf[..amount], true);
                     if let Ok(message) = message {
-                        if !receiving_requests.load(Ordering::SeqCst) {receiving_requests.store(true, Ordering::SeqCst)};
+                        if !receiving_requests.load(Ordering::SeqCst) {
+                            receiving_requests.store(true, Ordering::SeqCst);
+                            parent.unpark();
+                        };
                         let _ = self.handle_request(source, message);
                     }
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -304,6 +304,6 @@ impl DsServer for Arc<Server> {
     }
 
     fn last_request_duration(&self) -> Duration {
-        *self.last_request.lock().unwrap().elapsed()
+        {*self.last_request.lock().unwrap()}.elapsed()
     }
 }


### PR DESCRIPTION
Adds a few parameters to the server start method. Namely a receiving_requests parameter which takes an Arc<AtomicBool> that will be set to true whenever the server is receiving requests and a parent parameter which should be the parent Thread, will be unparked whenever requests start.